### PR TITLE
Fix typo in Italian locale for 'Enable'

### DIFF
--- a/src_frontend/locale/locale.it.json
+++ b/src_frontend/locale/locale.it.json
@@ -100,7 +100,7 @@
     "Decrease": "Diminuisci",
     "Disable": "Disattiva",
     "Double confirm power management": "Double confirm power management",
-    "Enable": "Attivta",
+    "Enable": "Attiva",
     "Gamepad Autorepeat Delay": "Gamepad Autorepeat Delay",
     "Increase": "Aumenta",
     "Recently Played Shelf": "Giocati di recente",


### PR DESCRIPTION
From `Attivta` to `Attiva`