### PR TITLE
Fixed typo in the disable settings prefix

### DIFF
--- a/src_backend/window_manager.cjs
+++ b/src_backend/window_manager.cjs
@@ -92,7 +92,7 @@ function toggleWindowShow() {
 
 function getHomePageUrl() {
   const queryParams = new URLSearchParams();
-  const disableFeatureEnvPrefix = "LUTRIS_GEMAPAD_UI_DISABLE_";
+  const disableFeatureEnvPrefix = "LUTRIS_GAMEPAD_UI_DISABLE_";
 
   for (const [k, v] of Object.entries(process.env)) {
     if (k.startsWith(disableFeatureEnvPrefix) && v === "1") {


### PR DESCRIPTION
Fixed LUTRIS_GEMAPAD_UI_DISABLE_ to LUTRIS_GAMEPAD_UI_DISABLE_ 