### PR TITLE
use XDG paths

### DIFF
--- a/electron.cjs
+++ b/electron.cjs
@@ -1,11 +1,5 @@
 const { app, Menu, protocol } = require("electron");
 
-const fs = require("node:fs");
-const path = require("node:path");
-const customSessionDataPath = path.join(app.getPath("home"), ".cache", "lutris-gamepad-ui");
-fs.mkdirSync(customSessionDataPath, { recursive: true });
-app.setPath('sessionData', customSessionDataPath);
-
 const { getAppConfig } = require("./src_backend/config_manager.cjs");
 const {
   closeRunningGameProcess,

--- a/electron.cjs
+++ b/electron.cjs
@@ -1,6 +1,7 @@
 const { app, Menu, protocol } = require("electron");
-const path = require("node:path");
 
+const fs = require("node:fs");
+const path = require("node:path");
 const customSessionDataPath = path.join(app.getPath("home"), ".cache", "lutris-gamepad-ui");
 fs.mkdirSync(customSessionPath, { recursive: true });
 app.setPath('sessionData', customSessionDataPath);

--- a/electron.cjs
+++ b/electron.cjs
@@ -3,7 +3,7 @@ const { app, Menu, protocol } = require("electron");
 const fs = require("node:fs");
 const path = require("node:path");
 const customSessionDataPath = path.join(app.getPath("home"), ".cache", "lutris-gamepad-ui");
-fs.mkdirSync(customSessionPath, { recursive: true });
+fs.mkdirSync(customSessionDataPath, { recursive: true });
 app.setPath('sessionData', customSessionDataPath);
 
 const { getAppConfig } = require("./src_backend/config_manager.cjs");

--- a/electron.cjs
+++ b/electron.cjs
@@ -1,4 +1,15 @@
 const { app, Menu, protocol } = require("electron");
+const { initializeSessionData } = require('./storage.cjs');
+
+const path = require('path');
+const cachePath = path.join(app.getPath("home"), ".cache", "lutris-gamepad-ui");
+try {
+  initializeSessionData(cachePath);
+} catch (error) {
+  console.error("Failed to initialize session data:", error.message);
+  // Handle the error
+}
+
 
 const { getAppConfig } = require("./src_backend/config_manager.cjs");
 const {

--- a/electron.cjs
+++ b/electron.cjs
@@ -1,5 +1,5 @@
 const { app, Menu, protocol } = require("electron");
-const { initializeSessionData } = require('./storage.cjs');
+const { initializeSessionData } = require('./src_backend/storage.cjs');
 
 const path = require('path');
 const cachePath = path.join(app.getPath("home"), ".cache", "lutris-gamepad-ui");

--- a/electron.cjs
+++ b/electron.cjs
@@ -1,5 +1,9 @@
 const { app, Menu, protocol } = require("electron");
 
+const customSessionDataPath = path.join(app.getPath("home"), ".cache", "lutris-gamepad-ui");
+fs.mkdirSync(customSessionPath, { recursive: true });
+app.setPath('sessionData', customSessionDataPath);
+
 const { getAppConfig } = require("./src_backend/config_manager.cjs");
 const {
   closeRunningGameProcess,

--- a/electron.cjs
+++ b/electron.cjs
@@ -1,4 +1,5 @@
 const { app, Menu, protocol } = require("electron");
+const path = require("node:path");
 
 const customSessionDataPath = path.join(app.getPath("home"), ".cache", "lutris-gamepad-ui");
 fs.mkdirSync(customSessionPath, { recursive: true });

--- a/src_backend/storage.cjs
+++ b/src_backend/storage.cjs
@@ -4,7 +4,7 @@ const path = require("node:path");
 const { app } = require("electron");
 
 function getAppHomeDir() {
-  const result = path.join(app.getPath("home"), ".local", "lutris-gamepad-ui");
+  const result = path.join(app.getPath("appData"), "lutris-gamepad-ui");
   fs.mkdirSync(result, { recursive: true });
   return result;
 }

--- a/src_backend/storage.cjs
+++ b/src_backend/storage.cjs
@@ -3,6 +3,10 @@ const path = require("node:path");
 
 const { app } = require("electron");
 
+const customSessionDataPath = path.join(app.getPath("home"), ".cache", "lutris-gamepad-ui");
+fs.mkdirSync(customSessionDataPath, { recursive: true });
+app.setPath('sessionData', customSessionDataPath);
+
 function getAppHomeDir() {
   const result = path.join(app.getPath("appData"), "lutris-gamepad-ui");
   fs.mkdirSync(result, { recursive: true });

--- a/src_backend/storage.cjs
+++ b/src_backend/storage.cjs
@@ -3,10 +3,6 @@ const path = require("node:path");
 
 const { app } = require("electron");
 
-const customSessionDataPath = path.join(app.getPath("home"), ".cache", "lutris-gamepad-ui");
-fs.mkdirSync(customSessionPath, { recursive: true });
-app.setPath('sessionData', customSessionDataPath);
-
 function getAppHomeDir() {
   const result = path.join(app.getPath("appData"), "lutris-gamepad-ui");
   fs.mkdirSync(result, { recursive: true });

--- a/src_backend/storage.cjs
+++ b/src_backend/storage.cjs
@@ -3,9 +3,10 @@ const path = require("node:path");
 
 const { app } = require("electron");
 
-const customSessionDataPath = path.join(app.getPath("home"), ".cache", "lutris-gamepad-ui");
-fs.mkdirSync(customSessionDataPath, { recursive: true });
-app.setPath('sessionData', customSessionDataPath);
+function initializeSessionData(customSessionDataPath) {
+  fs.mkdirSync(customSessionDataPath, { recursive: true });
+  app.setPath('sessionData', customSessionDataPath);
+}
 
 function getAppHomeDir() {
   const result = path.join(app.getPath("appData"), "lutris-gamepad-ui");
@@ -14,6 +15,8 @@ function getAppHomeDir() {
 }
 
 module.exports = {
+  initializeSessionData,
+  
   getThemeFilePath: () => {
     return path.join(getAppHomeDir(), "theme.json");
   },

--- a/src_backend/storage.cjs
+++ b/src_backend/storage.cjs
@@ -3,6 +3,10 @@ const path = require("node:path");
 
 const { app } = require("electron");
 
+const customSessionDataPath = path.join(app.getPath("home"), ".cache", "lutris-gamepad-ui");
+fs.mkdirSync(customSessionPath, { recursive: true });
+app.setPath('sessionData', customSessionDataPath);
+
 function getAppHomeDir() {
   const result = path.join(app.getPath("appData"), "lutris-gamepad-ui");
   fs.mkdirSync(result, { recursive: true });


### PR DESCRIPTION
use XDG specification paths.
move session data to .cache to free up config dir

**Warning!** I have not written any migration code. old config needs to be moved manually by user or recreated

Electron api example:
https://www.electronjs.org/docs/latest/api/app

sessionData path added to electron in 2022
https://github.com/electron/electron/pull/33554